### PR TITLE
feat: add database internals to reading list

### DIFF
--- a/src/data/reading.ts
+++ b/src/data/reading.ts
@@ -6,7 +6,14 @@ export interface ReadingItem {
     link?: string;
   }
   
-  export const readingData: ReadingItem[] = [
+export const readingData: ReadingItem[] = [
+    {
+      title: "Database Internals: A Deep Dive into How Distributed Data Systems Work",
+      author: "Alex Petrov",
+      type: "book",
+      status: "reading",
+      link: "https://www.amazon.com/Database-Internals-Deep-Distributed-Systems/dp/1492040347"
+    },
     {
       title: "Prometheus: Up & Running, 2nd Edition",
       author: "Brian Brazil",


### PR DESCRIPTION
## Summary
- add Database Internals by Alex Petrov to reading list data

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 3 errors, 6 warnings)
- `npx eslint src/data/reading.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a02f3fb250832a89decc80213d927b