### PR TITLE
fix: align reading and writing cards with responsive grid

### DIFF
--- a/src/pages/Reading.tsx
+++ b/src/pages/Reading.tsx
@@ -1,7 +1,5 @@
 import { Book, FileText, ExternalLink, CheckCircle, Clock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { readingData, ReadingItem } from "../data/reading";
 
 const Reading = () => {
@@ -11,8 +9,11 @@ const Reading = () => {
     const StatusIcon = item.status === "finished" ? CheckCircle : Clock;
 
     return (
-      <Card key={`${item.title}-${item.author}`} className="group hover:shadow-lg transition-shadow duration-200">
-        <CardHeader className="pb-3">
+      <article
+        key={`${item.title}-${item.author}`}
+        className="group flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
+      >
+        <header className="pb-3">
           <div className="flex items-start justify-between">
             <div className="flex items-center space-x-2">
               <TypeIcon className="h-5 w-5 text-muted-foreground" />
@@ -25,20 +26,24 @@ const Reading = () => {
               {item.status}
             </Badge>
           </div>
-          <CardTitle className="text-lg leading-tight">{item.title}</CardTitle>
+          <h3 className="mt-2 text-lg font-semibold leading-snug">{item.title}</h3>
           <p className="text-sm text-muted-foreground">by {item.author}</p>
-        </CardHeader>
+        </header>
+        <div className="mt-3 grow" />
         {item.link && (
-          <CardContent className="pt-0">
-            <Button variant="ghost" size="sm" asChild className="w-full justify-start">
-              <a href={item.link} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="h-4 w-4 mr-2" />
-                View {item.type === "book" ? "Book" : "Paper"}
-              </a>
-            </Button>
-          </CardContent>
+          <footer className="mt-4">
+            <a
+              href={item.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center text-sm underline underline-offset-2 hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+            >
+              <ExternalLink className="h-4 w-4 mr-2" />
+              View {item.type === "book" ? "Book" : "Paper"}
+            </a>
+          </footer>
         )}
-      </Card>
+      </article>
     );
   };
 
@@ -46,7 +51,7 @@ const Reading = () => {
   const papers = readingData.filter(item => item.type === "paper");
 
   return (
-    <div className="max-w-6xl mx-auto space-y-8">
+    <div className="mx-auto max-w-[1200px] px-4 md:px-6 space-y-8">
       <div className="text-center space-y-4">
         <h1 className="text-3xl md:text-4xl font-bold">Shelf</h1>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
@@ -63,7 +68,7 @@ const Reading = () => {
             <h2 className="text-2xl font-semibold">Books</h2>
             <Badge variant="secondary">{books.length}</Badge>
           </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid gap-4 md:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
             {books.map(renderReadingCard)}
           </div>
         </section>
@@ -77,7 +82,7 @@ const Reading = () => {
             <h2 className="text-2xl font-semibold">Research Papers</h2>
             <Badge variant="secondary">{papers.length}</Badge>
           </div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid gap-4 md:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
             {papers.map(renderReadingCard)}
           </div>
         </section>

--- a/src/pages/Reading.tsx
+++ b/src/pages/Reading.tsx
@@ -11,7 +11,7 @@ const Reading = () => {
     return (
       <article
         key={`${item.title}-${item.author}`}
-        className="group flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
+        className="group flex flex-col rounded-xl border border-border bg-card p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
       >
         <header className="pb-3">
           <div className="flex items-start justify-between">

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from "react";
-import { ExternalLink, Calendar, Clock } from "lucide-react";
+import { ExternalLink, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface BlogPost {
+  title: string;
+  link: string;
+  pubDate: string;
+  description: string;
+  thumbnail?: string;
+}
+
+interface RSSItem {
   title: string;
   link: string;
   pubDate: string;
@@ -20,7 +26,7 @@ const Writing = () => {
 
   const formatDescription = (htmlDescription: string): string => {
     // Remove HTML tags but preserve some structure
-    let text = htmlDescription
+    const text = htmlDescription
       .replace(/<\/p>/g, '\n\n') // Convert closing p tags to double line breaks
       .replace(/<\/h[1-6]>/g, '\n\n') // Convert closing header tags to double line breaks
       .replace(/<br\s*\/?>/g, '\n') // Convert br tags to line breaks
@@ -62,7 +68,7 @@ const Writing = () => {
         const data = await response.json();
         
         if (data.status === "ok") {
-          const formattedPosts = data.items.slice(0, 6).map((item: any) => ({
+          const formattedPosts = data.items.slice(0, 6).map((item: RSSItem) => ({
             title: item.title,
             link: item.link,
             pubDate: item.pubDate,
@@ -96,22 +102,28 @@ const Writing = () => {
 
   if (loading) {
     return (
-      <div className="max-w-6xl mx-auto space-y-8">
+      <div className="mx-auto max-w-[1200px] px-4 md:px-6 space-y-8">
         <div className="text-center space-y-4">
           <h1 className="text-3xl md:text-4xl font-bold">Writing</h1>
           <p className="text-lg text-muted-foreground">Loading latest posts...</p>
         </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid gap-4 md:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
           {[...Array(6)].map((_, i) => (
-            <Card key={i}>
-              <CardHeader>
+            <article
+              key={i}
+              className="flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm"
+            >
+              <header className="space-y-2">
                 <Skeleton className="h-4 w-3/4" />
                 <Skeleton className="h-3 w-1/2" />
-              </CardHeader>
-              <CardContent>
+              </header>
+              <div className="mt-3 grow">
                 <Skeleton className="h-20 w-full" />
-              </CardContent>
-            </Card>
+              </div>
+              <footer className="mt-4">
+                <Skeleton className="h-4 w-24" />
+              </footer>
+            </article>
           ))}
         </div>
       </div>
@@ -119,7 +131,7 @@ const Writing = () => {
   }
 
   return (
-    <div className="max-w-6xl mx-auto space-y-8">
+    <div className="mx-auto max-w-[1200px] px-4 md:px-6 space-y-8">
       <div className="text-center space-y-4">
         <h1 className="text-3xl md:text-4xl font-bold">Writing</h1>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
@@ -142,30 +154,38 @@ const Writing = () => {
         </Button>
       </div>
 
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid gap-4 md:gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 [grid-template-columns:repeat(auto-fit,minmax(320px,1fr))]">
         {posts.map((post, index) => (
-          <Card key={index} className="group hover:shadow-lg transition-shadow duration-200">
-            <CardHeader className="pb-3">
-              <div className="flex items-center space-x-2 text-sm text-muted-foreground mb-2">
+          <article
+            key={index}
+            className="group flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
+          >
+            <header>
+              <div className="mb-2 flex items-center space-x-2 text-sm text-muted-foreground">
                 <Calendar className="h-4 w-4" />
                 <span>{formatDate(post.pubDate)}</span>
               </div>
-              <CardTitle className="text-lg leading-tight group-hover:text-primary transition-colors">
+              <h3 className="text-lg font-semibold leading-snug group-hover:text-primary transition-colors">
                 {post.title}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
+              </h3>
+            </header>
+            <div className="mt-3 grow">
               <p className="text-sm text-muted-foreground whitespace-pre-line leading-relaxed">
                 {post.description}
               </p>
-              <Button variant="outline" size="sm" asChild className="w-full">
-                <a href={post.link} target="_blank" rel="noopener noreferrer">
-                  <ExternalLink className="h-4 w-4 mr-2" />
-                  Read on Medium
-                </a>
-              </Button>
-            </CardContent>
-          </Card>
+            </div>
+            <footer className="mt-4">
+              <a
+                href={post.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center text-sm underline underline-offset-2 hover:text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              >
+                <ExternalLink className="h-4 w-4 mr-2" />
+                Read on Medium
+              </a>
+            </footer>
+          </article>
         ))}
       </div>
 

--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -111,7 +111,7 @@ const Writing = () => {
           {[...Array(6)].map((_, i) => (
             <article
               key={i}
-              className="flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm"
+              className="flex flex-col rounded-xl border border-border bg-card p-6 shadow-sm"
             >
               <header className="space-y-2">
                 <Skeleton className="h-4 w-3/4" />
@@ -158,7 +158,7 @@ const Writing = () => {
         {posts.map((post, index) => (
           <article
             key={index}
-            className="group flex flex-col rounded-xl border border-neutral-800 bg-neutral-900/60 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
+            className="group flex flex-col rounded-xl border border-border bg-card p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus-within:-translate-y-0.5 focus-within:shadow-md"
           >
             <header>
               <div className="mb-2 flex items-center space-x-2 text-sm text-muted-foreground">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- switch reading and writing pages to CSS grid layout with auto-fit columns
- refactor card markup to semantic `<article>` with pinned footer and focus styles
- replace require usage in Tailwind config with ES module import

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a032ca7e80832aaf51a0f1b00794df