### PR TITLE
feat: redirect medium paths

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { Toaster } from "@/components/ui/toaster";
 import Layout from "./components/Layout";
@@ -6,6 +6,7 @@ import Home from "./pages/Home";
 import About from "./pages/About";
 import Reading from "./pages/Reading";
 import Writing from "./pages/Writing";
+import MediumRedirect from "./pages/MediumRedirect";
 import "./App.css";
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
             <Route path="/about" element={<About />} />
             <Route path="/reading" element={<Reading />} />
             <Route path="/writing" element={<Writing />} />
+            <Route path="/medium/*" element={<MediumRedirect />} />
           </Routes>
         </Layout>
         <Toaster />

--- a/src/pages/MediumRedirect.tsx
+++ b/src/pages/MediumRedirect.tsx
@@ -1,0 +1,10 @@
+import { Navigate, useLocation } from "react-router-dom";
+
+const MediumRedirect = () => {
+  const location = useLocation();
+  const path = location.pathname.replace(/^\/medium\/?/, "");
+  const target = `https://kapillamba4.medium.com/${path}${location.search}${location.hash}`;
+  return <Navigate to={target} replace />;
+};
+
+export default MediumRedirect;


### PR DESCRIPTION
## Summary
- add React route that redirects `/medium/*` to `https://kapillamba4.medium.com/*`
- switch to hash-based routing so GitHub Pages can serve `/medium/*` paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc9c862c64832a954e031a8fe3854c