### PR TITLE
Show all Medium posts on writing page

### DIFF
--- a/src/pages/Writing.tsx
+++ b/src/pages/Writing.tsx
@@ -68,7 +68,7 @@ const Writing = () => {
         const data = await response.json();
         
         if (data.status === "ok") {
-          const formattedPosts = data.items.slice(0, 6).map((item: RSSItem) => ({
+          const formattedPosts = data.items.map((item: RSSItem) => ({
             title: item.title,
             link: item.link,
             pubDate: item.pubDate,


### PR DESCRIPTION
## Summary
- remove the client-side limit so the writing page displays all Medium posts returned by the feed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6900b64b91a8832aa29284f5006879ba